### PR TITLE
Performance improvements, refactoring and tidying up readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+.mypy_cache
+*.prof
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+*.html
+
+# Dependency directories (remove the comment below to include it)
+# vendor/

--- a/common.go
+++ b/common.go
@@ -1,0 +1,16 @@
+// Package intset provides a specialized set for integers or runes
+package intset
+
+const bucketSize, bucketGrowBy, bucketMultiplier int = 4, 1, 1
+
+// http://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
+func upTwo(v int) int {
+	v--
+	v |= v >> 1
+	v |= v >> 2
+	v |= v >> 4
+	v |= v >> 8
+	v |= v >> 16
+	v++
+	return v
+}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/elliotwutingfeng/intset
+module github.com/karlseguin/intset
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module intset
+module github.com/elliotwutingfeng/intset
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module intset
+
+go 1.18
+
+require github.com/karlseguin/expect v1.0.8
+
+require github.com/wsxiaoys/terminal v0.0.0-20160513160801-0940f3fc43a0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/karlseguin/expect v1.0.8 h1:Bb0H6IgBWQpadY25UDNkYPDB9ITqK1xnSoZfAq362fw=
+github.com/karlseguin/expect v1.0.8/go.mod h1:lXdI8iGiQhmzpnnmU/EGA60vqKs8NbRNFnhhrJGoD5g=
+github.com/wsxiaoys/terminal v0.0.0-20160513160801-0940f3fc43a0 h1:3UeQBvD0TFrlVjOeLOBz+CPAI8dnbqNSVwUwRrkp7vQ=
+github.com/wsxiaoys/terminal v0.0.0-20160513160801-0940f3fc43a0/go.mod h1:IXCdmsXIht47RaVFLEdVnh1t+pgYtTAhQGj73kz+2DM=

--- a/license.txt
+++ b/license.txt
@@ -1,3 +1,4 @@
+Copyright (c) 2022 Wu Tingfeng.
 Copyright (c) 2015 Karl Seguin.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/readme.md
+++ b/readme.md
@@ -1,30 +1,32 @@
 # IntSet
 
-A specialized set for integers, ideal when:
+[![Go Reference](https://img.shields.io/badge/go-reference-blue?logo=go&logoColor=white&style=for-the-badge)](https://pkg.go.dev/github.com/karlseguin/intset)
+[![Go Report Card](https://goreportcard.com/badge/github.com/karlseguin/intset?style=for-the-badge)](https://goreportcard.com/report/github.com/karlseguin/intset)
+[![GitHub license](https://img.shields.io/badge/LICENSE-MIT-GREEN?style=for-the-badge)](LICENSE)
+
+A specialized set for integers or runes, ideal when:
 
 - The number of elements is known ahead of time (or a good approximation)
 - The number of elements doesn't change drastically over time
 - The values are naturally random
 
-As long as the number of elements within the set stays close to the originally specified size (I don't know the magic number, so let's say ±10%), and that they stay evenly distributed. the set will exhibit good read and write performance, as well as decent memory usage. When packed, read performance is roughly 2x better than a map[int]struct{} with memory usage less than 1/2.
+As long as the number of elements within the set stays close to the originally specified size (I don't know the magic number, so let's say ±10%), and that they stay evenly distributed. the set will exhibit good read and write performance, as well as decent memory usage. When packed, read performance is roughly 7 times better than a map[int]struct{}.
 
 ```go
-set := intset.NewSized(1000000)  //or intset.NewSized32(100000) or intset.NewRune(100000)
+set := intset.NewSized(1000000)  // or intset.NewSized32(100000) or intset.NewRune(100000)
 set.Set(32)
 set.Exists(32)
 ```
 
 ## Methods
 
-The `int`, `uint32` and `rune` variations have the same API (except for the obvious difference that each variation deals with `int`, `uint32`, and `rune` respectively).
+The `int`, `uint32` and `rune` variations have the same API.
 
-- `Set(int)`
-- `Exits(int) bool`
-- `Remove(int) bool`
+- `Set(int)` or `Set(uint32)` or `Set(rune)`
+- `Exists(int) bool` or `Exists(uint32) bool` or `Exists(rune) bool`
+- `Remove(int) bool` or `Remove(uint32) bool` or `Remove(rune) bool`
 - `Len() int`
-- `Each(f func(value int))`
-
-(It's hopefully obviously where a `uint32` is expected when dealing with the `uint32` variant, likewise for the `rune` variant)
+- `Each(f func(value int))` or `Each(f func(value uint32))` or `Each(f func(value rune))`
 
 ## Intersections and Unions
 
@@ -34,9 +36,9 @@ The method is called via:
 
 ```go
 result := intset.Intersect([]Set{s1, s2})
-//or
+// or
 result := intset.Intersect32([]Set32{s1, s2})
-//or
+// or
 result := intset.IntersectRune([]Set32{s1, s2})
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ A specialized set for integers, ideal when:
 As long as the number of elements within the set stays close to the originally specified size (I don't know the magic number, so let's say ±10%), and that they stay evenly distributed. the set will exhibit good read and write performance, as well as decent memory usage. When packed, read performance is roughly 2x better than a map[int]struct{} with memory usage less than 1/2.
 
 ```go
-set := intset.NewSized(1000000)  //or intset.NewSized32(100000)
+set := intset.NewSized(1000000)  //or intset.NewSized32(100000) or intset.NewRune(100000)
 set.Set(32)
 set.Exists(32)
 ```

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,5 @@
+# IntSet
+
 A specialized set for integers, ideal when:
 
 - The number of elements is known ahead of time (or a good approximation)
@@ -6,15 +8,15 @@ A specialized set for integers, ideal when:
 
 As long as the number of elements within the set stays close to the originally specified size (I don't know the magic number, so let's say ±10%), and that they stay evenly distributed. the set will exhibit good read and write performance, as well as decent memory usage. When packed, read performance is roughly 2x better than a map[int]struct{} with memory usage less than 1/2.
 
-
 ```go
-set := intset.Sized(1000000)  //or inteet.Sized32(100000)
+set := intset.NewSized(1000000)  //or intset.NewSized32(100000)
 set.Set(32)
 set.Exists(32)
 ```
 
 ## Methods
-The `int` and `uint32` variations have the same API (except for the obvious difference that one deals with `int` and the other with `uint32`).
+
+The `int`, `uint32` and `rune` variations have the same API (except for the obvious difference that each variation deals with `int`, `uint32`, and `rune` respectively).
 
 - `Set(int)`
 - `Exits(int) bool`
@@ -22,10 +24,11 @@ The `int` and `uint32` variations have the same API (except for the obvious diff
 - `Len() int`
 - `Each(f func(value int))`
 
-(It's hopefully obviously where a `uint32` is expected when dealing with the `uint32` variant)
+(It's hopefully obviously where a `uint32` is expected when dealing with the `uint32` variant, likewise for the `rune` variant)
 
 ## Intersections and Unions
-Two or more sets can be intersected by calling `Intersect` or `Intersect32`. This is largely a reference implementation and callers should consider implementing their own. For example, maybe you want to stop after finding X matches, want to use a pooled array object to hold intermediary objects, or are fine with getting an array back (rather than a set) (all of which should result in much better performance).
+
+Two or more sets can be intersected by calling `Intersect`, `Intersect32`, or `IntersectRune`. This is largely a reference implementation and callers should consider implementing their own. For example, maybe you want to stop after finding X matches, want to use a pooled array object to hold intermediary objects, or are fine with getting an array back (rather than a set) (all of which should result in much better performance).
 
 The method is called via:
 
@@ -33,6 +36,8 @@ The method is called via:
 result := intset.Intersect([]Set{s1, s2})
 //or
 result := intset.Intersect32([]Set32{s1, s2})
+//or
+result := intset.IntersectRune([]Set32{s1, s2})
 ```
 
-`Union` and `Union32` can be similarly used.
+`Union`, `Union32`, and `UnionRune` can be similarly used.

--- a/rune.go
+++ b/rune.go
@@ -3,23 +3,25 @@ package intset
 
 import "sort"
 
-type runeSet interface {
+// Rune defines rune set methods
+type Rune interface {
 	Len() int
 	Exists(value rune) bool
 	Each(f func(value rune))
 }
 
-type runeSets []runeSet
+// Runes is array of Rune
+type Runes []Rune
 
-func (s runeSets) Len() int {
+func (s Runes) Len() int {
 	return len(s)
 }
 
-func (s runeSets) Less(i, j int) bool {
+func (s Runes) Less(i, j int) bool {
 	return s[i].Len() < s[j].Len()
 }
 
-func (s runeSets) Swap(i, j int) {
+func (s Runes) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
 
@@ -150,7 +152,7 @@ func (s SizedRune) exists(value rune, bucket []rune) bool {
 }
 
 // IntersectRune returns the intersection of an array of sets
-func IntersectRune(sets runeSets) *SizedRune {
+func IntersectRune(sets Runes) *SizedRune {
 	sort.Sort(sets)
 	a, l := sets[0], sets.Len()
 	values := make([]rune, 0, a.Len())
@@ -170,7 +172,7 @@ func IntersectRune(sets runeSets) *SizedRune {
 }
 
 // UnionRune returns the union of an array of sets
-func UnionRune(sets runeSets) *SizedRune {
+func UnionRune(sets Runes) *SizedRune {
 	values := make(map[rune]struct{}, sets[0].Len())
 	for i := 0; i < sets.Len(); i++ {
 		sets[i].Each(func(value rune) {

--- a/rune.go
+++ b/rune.go
@@ -30,11 +30,11 @@ type Rune struct {
 }
 
 func NewRune(size rune) *Rune {
-	if size < rune(BUCKET_SIZE) {
+	if size < rune(bucketSize) {
 		//random, no clue what to make it
-		size = rune(BUCKET_SIZE * 2)
+		size = rune(bucketSize) * rune(bucketMultiplier)
 	}
-	count := upTwo(int(size) / BUCKET_SIZE)
+	count := upTwo(int(size) / bucketSize)
 	s := &Rune{
 		mask:    rune(count) - 1,
 		buckets: make([][]rune, count),
@@ -51,7 +51,7 @@ func (s *Rune) Set(value rune) {
 	}
 	l := len(bucket)
 	if cap(bucket) == l {
-		n := make([]rune, l, l+BUCKET_GROW_BY)
+		n := make([]rune, l, l+bucketGrowBy)
 		copy(n, bucket)
 		bucket = n
 	}
@@ -110,7 +110,7 @@ func (s Rune) index(value rune, bucket []rune) (int, bool) {
 		return l, true
 	}
 
-	offset, i := 0, 0
+	var offset, i int
 	if value > v {
 		offset = l
 		bucket = bucket[offset:]

--- a/rune.go
+++ b/rune.go
@@ -107,19 +107,17 @@ func (s Rune) index(value rune, bucket []rune) (int, bool) {
 	if value == v {
 		return l, true
 	}
-
-	var offset, i int
 	if value > v {
-		offset = l
-		bucket = bucket[offset:]
+		bucket = bucket[l:]
 	}
 
+	var i int
 	for i, v = range bucket {
 		if v >= value {
-			return offset + i, v == value
+			return l + i, v == value
 		}
 	}
-	return offset + i + 1, false
+	return l + i + 1, false
 }
 
 func (s Rune) exists(value rune, bucket []rune) bool {

--- a/rune.go
+++ b/rune.go
@@ -109,6 +109,8 @@ func (s Rune) index(value rune, bucket []rune) (int, bool) {
 	}
 	if value > v {
 		bucket = bucket[l:]
+	} else {
+		l = 0
 	}
 
 	var i int

--- a/rune.go
+++ b/rune.go
@@ -80,9 +80,7 @@ func (s *Rune) Remove(value rune) bool {
 }
 
 func (s *Rune) Exists(value rune) bool {
-	bucket := s.buckets[value&s.mask]
-	_, exists := s.index(value, bucket)
-	return exists
+	return s.exists(value, s.buckets[value&s.mask])
 }
 
 func (s Rune) Len() int {
@@ -117,12 +115,34 @@ func (s Rune) index(value rune, bucket []rune) (int, bool) {
 	}
 
 	for i, v = range bucket {
-		if v < value {
-			continue
+		if v >= value {
+			return offset + i, v == value
 		}
-		return offset + i, v == value
 	}
 	return offset + i + 1, false
+}
+
+func (s Rune) exists(value rune, bucket []rune) bool {
+	l := len(bucket)
+	if l == 0 {
+		return false
+	}
+
+	l = l / 2
+	v := bucket[l]
+	if value == v {
+		return true
+	}
+	if value > v {
+		bucket = bucket[l:]
+	}
+
+	for _, v = range bucket {
+		if v >= value {
+			return v == value
+		}
+	}
+	return false
 }
 
 func IntersectRune(sets SetsRune) *Rune {

--- a/rune.go
+++ b/rune.go
@@ -1,0 +1,159 @@
+// integer set
+package intset
+
+import "sort"
+
+type SetRune interface {
+	Len() int
+	Exists(value rune) bool
+	Each(f func(value rune))
+}
+
+type SetsRune []SetRune
+
+func (s SetsRune) Len() int {
+	return len(s)
+}
+
+func (s SetsRune) Less(i, j int) bool {
+	return s[i].Len() < s[j].Len()
+}
+
+func (s SetsRune) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+type Rune struct {
+	mask    rune
+	buckets [][]rune
+	length  int
+}
+
+func NewRune(size rune) *Rune {
+	if size < rune(BUCKET_SIZE) {
+		//random, no clue what to make it
+		size = rune(BUCKET_SIZE * 2)
+	}
+	count := upTwo(int(size) / BUCKET_SIZE)
+	s := &Rune{
+		mask:    rune(count) - 1,
+		buckets: make([][]rune, count),
+	}
+	return s
+}
+
+func (s *Rune) Set(value rune) {
+	index := value & s.mask
+	bucket := s.buckets[index]
+	position, exists := s.index(value, bucket)
+	if exists {
+		return
+	}
+	l := len(bucket)
+	if cap(bucket) == l {
+		n := make([]rune, l, l+BUCKET_GROW_BY)
+		copy(n, bucket)
+		bucket = n
+	}
+	bucket = append(bucket, value)
+	if position != l {
+		copy(bucket[position+1:], bucket[position:])
+		bucket[position] = value
+	}
+	s.length++
+	s.buckets[index] = bucket
+}
+
+// returns true if the value existed
+func (s *Rune) Remove(value rune) bool {
+	index := value & s.mask
+	bucket := s.buckets[index]
+	position, exists := s.index(value, bucket)
+	if exists == false {
+		return false
+	}
+	l := len(bucket) - 1
+	bucket[position], bucket[l] = bucket[l], bucket[position]
+	s.buckets[index] = bucket[:l]
+	s.length--
+	return true
+}
+
+func (s *Rune) Exists(value rune) bool {
+	bucket := s.buckets[value&s.mask]
+	_, exists := s.index(value, bucket)
+	return exists
+}
+
+func (s Rune) Len() int {
+	return s.length
+}
+
+// Iterate through the set items
+func (s Rune) Each(f func(value rune)) {
+	for _, bucket := range s.buckets {
+		for _, value := range bucket {
+			f(value)
+		}
+	}
+}
+
+func (s Rune) index(value rune, bucket []rune) (int, bool) {
+	l := len(bucket)
+	if l == 0 {
+		return 0, false
+	}
+
+	l = l / 2
+	v := bucket[l]
+	if value == v {
+		return l, true
+	}
+
+	offset, i := 0, 0
+	if value > v {
+		offset = l
+		bucket = bucket[offset:]
+	}
+
+	for i, v = range bucket {
+		if v < value {
+			continue
+		}
+		return offset + i, v == value
+	}
+	return offset + i + 1, false
+}
+
+func IntersectRune(sets SetsRune) *Rune {
+	sort.Sort(sets)
+	a, l := sets[0], sets.Len()
+	values := make([]rune, 0, a.Len())
+	a.Each(func(value rune) {
+		for i := 1; i < l; i++ {
+			if sets[i].Exists(value) == false {
+				return
+			}
+		}
+		values = append(values, value)
+	})
+	s := NewRune(rune(len(values)))
+	for _, value := range values {
+		s.Set(value)
+	}
+	return s
+}
+
+func UnionRune(sets SetsRune) *Rune {
+	values := make(map[rune]struct{}, sets[0].Len())
+	for i := 0; i < sets.Len(); i++ {
+		sets[i].Each(func(value rune) {
+			values[value] = struct{}{}
+		})
+	}
+	s := NewRune(rune(len(values)))
+	for value := range values {
+		s.Set(value)
+	}
+	return s
+}

--- a/rune.go
+++ b/rune.go
@@ -3,42 +3,42 @@ package intset
 
 import "sort"
 
-// Rune defines rune set methods
-type Rune interface {
+// SetRune defines rune set methods
+type SetRune interface {
 	Len() int
 	Exists(value rune) bool
 	Each(f func(value rune))
 }
 
-// Runes is array of Rune
-type Runes []Rune
+// SetsRune is array of Rune
+type SetsRune []SetRune
 
-func (s Runes) Len() int {
+func (s SetsRune) Len() int {
 	return len(s)
 }
 
-func (s Runes) Less(i, j int) bool {
+func (s SetsRune) Less(i, j int) bool {
 	return s[i].Len() < s[j].Len()
 }
 
-func (s Runes) Swap(i, j int) {
+func (s SetsRune) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
 
-// SizedRune stores rune set data
-type SizedRune struct {
+// Rune stores rune set data
+type Rune struct {
 	mask    rune
 	buckets [][]rune
 	length  int
 }
 
 // NewRune creates an empty rune set with target capacity specified by size
-func NewRune(size rune) *SizedRune {
+func NewRune(size rune) *Rune {
 	if size < rune(bucketSize) {
 		size = rune(bucketSize) * rune(bucketMultiplier)
 	}
 	count := upTwo(int(size) / bucketSize)
-	s := &SizedRune{
+	s := &Rune{
 		mask:    rune(count) - 1,
 		buckets: make([][]rune, count),
 	}
@@ -46,7 +46,7 @@ func NewRune(size rune) *SizedRune {
 }
 
 // Set adds a value to the rune set
-func (s *SizedRune) Set(value rune) {
+func (s *Rune) Set(value rune) {
 	index := value & s.mask
 	bucket := s.buckets[index]
 	position, exists := s.index(value, bucket)
@@ -69,7 +69,7 @@ func (s *SizedRune) Set(value rune) {
 }
 
 // Remove returns true if the value existed in the rune set before being removed
-func (s *SizedRune) Remove(value rune) bool {
+func (s *Rune) Remove(value rune) bool {
 	index := value & s.mask
 	bucket := s.buckets[index]
 	position, exists := s.index(value, bucket)
@@ -84,17 +84,17 @@ func (s *SizedRune) Remove(value rune) bool {
 }
 
 // Exists returns true if the value exists in the set
-func (s *SizedRune) Exists(value rune) bool {
+func (s *Rune) Exists(value rune) bool {
 	return s.exists(value, s.buckets[value&s.mask])
 }
 
 // Len returns the total number of elements in the set
-func (s SizedRune) Len() int {
+func (s Rune) Len() int {
 	return s.length
 }
 
 // Each iterates through the set items and applies function f to each set item
-func (s SizedRune) Each(f func(value rune)) {
+func (s Rune) Each(f func(value rune)) {
 	for _, bucket := range s.buckets {
 		for _, value := range bucket {
 			f(value)
@@ -102,7 +102,7 @@ func (s SizedRune) Each(f func(value rune)) {
 	}
 }
 
-func (s SizedRune) index(value rune, bucket []rune) (int, bool) {
+func (s Rune) index(value rune, bucket []rune) (int, bool) {
 	l := len(bucket)
 	if l == 0 {
 		return 0, false
@@ -128,7 +128,7 @@ func (s SizedRune) index(value rune, bucket []rune) (int, bool) {
 	return l + i + 1, false
 }
 
-func (s SizedRune) exists(value rune, bucket []rune) bool {
+func (s Rune) exists(value rune, bucket []rune) bool {
 	l := len(bucket)
 	if l == 0 {
 		return false
@@ -152,7 +152,7 @@ func (s SizedRune) exists(value rune, bucket []rune) bool {
 }
 
 // IntersectRune returns the intersection of an array of sets
-func IntersectRune(sets Runes) *SizedRune {
+func IntersectRune(sets SetsRune) *Rune {
 	sort.Sort(sets)
 	a, l := sets[0], sets.Len()
 	values := make([]rune, 0, a.Len())
@@ -172,7 +172,7 @@ func IntersectRune(sets Runes) *SizedRune {
 }
 
 // UnionRune returns the union of an array of sets
-func UnionRune(sets Runes) *SizedRune {
+func UnionRune(sets SetsRune) *Rune {
 	values := make(map[rune]struct{}, sets[0].Len())
 	for i := 0; i < sets.Len(); i++ {
 		sets[i].Each(func(value rune) {

--- a/rune_test.go
+++ b/rune_test.go
@@ -35,7 +35,7 @@ func (RuneTest) Exists() {
 }
 
 func (RuneTest) SizeLessThanBucket() {
-	s := NewRune(rune(BUCKET_SIZE) - 1)
+	s := NewRune(rune(bucketSize) - 1)
 	s.Set(32)
 	expect.Expect(s.Exists(32)).To.Equal(true)
 	expect.Expect(s.Exists(33)).To.Equal(false)
@@ -109,12 +109,9 @@ func Benchmark_RuneDenseExists(b *testing.B) {
 	for i := rune(0); i < 1000000; i++ {
 		s.Set(i)
 	}
-	misses := 0
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if s.Exists(rune(i%1000000)) == false {
-			misses++
-		}
+		s.Exists(rune(i % 1000000))
 	}
 }
 
@@ -125,11 +122,8 @@ func Benchmark_RuneSparseExists(b *testing.B) {
 			s.Set(i)
 		}
 	}
-	misses := 0
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if s.Exists(rune(i%1000000)) == false {
-			misses++
-		}
+		s.Exists(rune(i % 1000000))
 	}
 }

--- a/rune_test.go
+++ b/rune_test.go
@@ -6,49 +6,49 @@ import (
 	expect "github.com/karlseguin/expect"
 )
 
-type Sized32Test struct{}
+type RuneTest struct{}
 
-func Test_Sized32(t *testing.T) {
-	expect.Expectify(new(Sized32Test), t)
+func Test_Rune(t *testing.T) {
+	expect.Expectify(new(RuneTest), t)
 }
 
-func (Sized32Test) SetsAValue() {
-	s := NewSized32(20)
-	for i := uint32(0); i < 30; i++ {
+func (RuneTest) SetsAValue() {
+	s := NewRune(20)
+	for i := rune(0); i < 30; i++ {
 		s.Set(i)
 		expect.Expect(s.Exists(i)).To.Equal(true)
 	}
-	for i := uint32(0); i < 30; i++ {
+	for i := rune(0); i < 30; i++ {
 		expect.Expect(s.Exists(i)).To.Equal(true)
 	}
 }
 
-func (Sized32Test) Exists() {
-	s := NewSized32(20)
-	for i := uint32(0); i < 10; i++ {
+func (RuneTest) Exists() {
+	s := NewRune(20)
+	for i := rune(0); i < 10; i++ {
 		expect.Expect(s.Exists(i)).To.Equal(false)
 		s.Set(i)
 	}
-	for i := uint32(0); i < 10; i++ {
+	for i := rune(0); i < 10; i++ {
 		expect.Expect(s.Exists(i)).To.Equal(true)
 	}
 }
 
-func (Sized32Test) SizeLessThanBucket() {
-	s := NewSized32(uint32(BUCKET_SIZE) - 1)
+func (RuneTest) SizeLessThanBucket() {
+	s := NewRune(rune(BUCKET_SIZE) - 1)
 	s.Set(32)
 	expect.Expect(s.Exists(32)).To.Equal(true)
 	expect.Expect(s.Exists(33)).To.Equal(false)
 }
 
-func (Sized32Test) RemoveNonMembers() {
-	s := NewSized32(100)
+func (RuneTest) RemoveNonMembers() {
+	s := NewRune(100)
 	expect.Expect(s.Remove(329)).To.Equal(false)
 }
 
-func (Sized32Test) RemovesMembers() {
-	s := NewSized32(100)
-	for i := uint32(0); i < 10; i++ {
+func (RuneTest) RemovesMembers() {
+	s := NewRune(100)
+	for i := rune(0); i < 10; i++ {
 		s.Set(i)
 	}
 	expect.Expect(s.Remove(20)).To.Equal(false)
@@ -58,9 +58,9 @@ func (Sized32Test) RemovesMembers() {
 	expect.Expect(s.Len()).To.Equal(9)
 }
 
-func (Sized32Test) IntersectsTwoSets() {
-	s1 := NewSized32(10)
-	s2 := NewSized32(10)
+func (RuneTest) IntersectsTwoSets() {
+	s1 := NewRune(10)
+	s2 := NewRune(10)
 	s1.Set(1)
 	s1.Set(2)
 	s1.Set(3)
@@ -69,7 +69,7 @@ func (Sized32Test) IntersectsTwoSets() {
 	s2.Set(3)
 	s2.Set(4)
 
-	s := Intersect32([]Set32{s1, s2})
+	s := IntersectRune([]SetRune{s1, s2})
 	expect.Expect(s.Exists(1)).To.Equal(false)
 	expect.Expect(s.Exists(2)).To.Equal(true)
 	expect.Expect(s.Exists(3)).To.Equal(true)
@@ -77,9 +77,9 @@ func (Sized32Test) IntersectsTwoSets() {
 	expect.Expect(s.Exists(5)).To.Equal(false)
 }
 
-func (Sized32Test) UnionsTwoSets() {
-	s1 := NewSized32(10)
-	s2 := NewSized32(10)
+func (RuneTest) UnionsTwoSets() {
+	s1 := NewRune(10)
+	s2 := NewRune(10)
 	s1.Set(1)
 	s1.Set(2)
 	s1.Set(3)
@@ -88,7 +88,7 @@ func (Sized32Test) UnionsTwoSets() {
 	s2.Set(3)
 	s2.Set(4)
 
-	s := Union32([]Set32{s1, s2})
+	s := UnionRune([]SetRune{s1, s2})
 	expect.Expect(s.Exists(1)).To.Equal(true)
 	expect.Expect(s.Exists(2)).To.Equal(true)
 	expect.Expect(s.Exists(3)).To.Equal(true)
@@ -96,31 +96,31 @@ func (Sized32Test) UnionsTwoSets() {
 	expect.Expect(s.Exists(5)).To.Equal(false)
 }
 
-func Benchmark_Sized32Populate(b *testing.B) {
-	s := NewSized32(10000000)
+func Benchmark_RunePopulate(b *testing.B) {
+	s := NewRune(10000000)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		s.Set(uint32(i % 10000000))
+		s.Set(rune(i % 10000000))
 	}
 }
 
-func Benchmark_Sized32DenseExists(b *testing.B) {
-	s := NewSized32(1000000)
-	for i := uint32(0); i < 1000000; i++ {
+func Benchmark_RuneDenseExists(b *testing.B) {
+	s := NewRune(1000000)
+	for i := rune(0); i < 1000000; i++ {
 		s.Set(i)
 	}
 	misses := 0
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if s.Exists(uint32(i%1000000)) == false {
+		if s.Exists(rune(i%1000000)) == false {
 			misses++
 		}
 	}
 }
 
-func Benchmark_Sized32SparseExists(b *testing.B) {
-	s := NewSized32(1000000)
-	for i := uint32(0); i < 1000000; i++ {
+func Benchmark_RuneSparseExists(b *testing.B) {
+	s := NewRune(1000000)
+	for i := rune(0); i < 1000000; i++ {
 		if i%10 == 0 {
 			s.Set(i)
 		}
@@ -128,7 +128,7 @@ func Benchmark_Sized32SparseExists(b *testing.B) {
 	misses := 0
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if s.Exists(uint32(i%1000000)) == false {
+		if s.Exists(rune(i%1000000)) == false {
 			misses++
 		}
 	}

--- a/rune_test.go
+++ b/rune_test.go
@@ -70,7 +70,7 @@ func (RuneTest) IntersectsTwoSets() {
 	s2.Set(3)
 	s2.Set(4)
 
-	s := IntersectRune([]Rune{s1, s2})
+	s := IntersectRune([]SetRune{s1, s2})
 	expect.Expect(s.Exists(1)).To.Equal(false)
 	expect.Expect(s.Exists(2)).To.Equal(true)
 	expect.Expect(s.Exists(3)).To.Equal(true)
@@ -89,7 +89,7 @@ func (RuneTest) UnionsTwoSets() {
 	s2.Set(3)
 	s2.Set(4)
 
-	s := UnionRune([]Rune{s1, s2})
+	s := UnionRune([]SetRune{s1, s2})
 	expect.Expect(s.Exists(1)).To.Equal(true)
 	expect.Expect(s.Exists(2)).To.Equal(true)
 	expect.Expect(s.Exists(3)).To.Equal(true)
@@ -144,7 +144,7 @@ func Benchmark_RuneDenseIntersect(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		IntersectRune([]Rune{s1, s2})
+		IntersectRune([]SetRune{s1, s2})
 	}
 }
 

--- a/rune_test.go
+++ b/rune_test.go
@@ -1,6 +1,7 @@
 package intset
 
 import (
+	"math/rand"
 	"testing"
 
 	expect "github.com/karlseguin/expect"
@@ -69,7 +70,7 @@ func (RuneTest) IntersectsTwoSets() {
 	s2.Set(3)
 	s2.Set(4)
 
-	s := IntersectRune([]SetRune{s1, s2})
+	s := IntersectRune([]runeSet{s1, s2})
 	expect.Expect(s.Exists(1)).To.Equal(false)
 	expect.Expect(s.Exists(2)).To.Equal(true)
 	expect.Expect(s.Exists(3)).To.Equal(true)
@@ -88,7 +89,7 @@ func (RuneTest) UnionsTwoSets() {
 	s2.Set(3)
 	s2.Set(4)
 
-	s := UnionRune([]SetRune{s1, s2})
+	s := UnionRune([]runeSet{s1, s2})
 	expect.Expect(s.Exists(1)).To.Equal(true)
 	expect.Expect(s.Exists(2)).To.Equal(true)
 	expect.Expect(s.Exists(3)).To.Equal(true)
@@ -125,5 +126,50 @@ func Benchmark_RuneSparseExists(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		s.Exists(rune(i % 1000000))
+	}
+}
+
+func Benchmark_RuneDenseIntersect(b *testing.B) {
+	s1 := NewRune(100000)
+	for i := rune(0); i < 100000; i++ {
+		if rand.Intn(10) != 0 {
+			s1.Set(i)
+		}
+	}
+	s2 := NewRune(1000)
+	for i := rune(0); i < 1000; i++ {
+		if rand.Intn(10) != 0 {
+			s2.Set(i)
+		}
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		IntersectRune([]runeSet{s1, s2})
+	}
+}
+
+// Benchmarks for map[rune]struct{}
+
+func Benchmark_RuneMapDenseExists(b *testing.B) {
+	s := make(map[rune]struct{})
+	for i := rune(0); i < 1000000; i++ {
+		s[i] = struct{}{}
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = s[rune(i)]
+	}
+}
+
+func Benchmark_RuneMapSparseExists(b *testing.B) {
+	s := make(map[rune]struct{})
+	for i := rune(0); i < 1000000; i++ {
+		if i%10 == 0 {
+			s[i] = struct{}{}
+		}
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = s[rune(i%1000000)]
 	}
 }

--- a/rune_test.go
+++ b/rune_test.go
@@ -70,7 +70,7 @@ func (RuneTest) IntersectsTwoSets() {
 	s2.Set(3)
 	s2.Set(4)
 
-	s := IntersectRune([]runeSet{s1, s2})
+	s := IntersectRune([]Rune{s1, s2})
 	expect.Expect(s.Exists(1)).To.Equal(false)
 	expect.Expect(s.Exists(2)).To.Equal(true)
 	expect.Expect(s.Exists(3)).To.Equal(true)
@@ -89,7 +89,7 @@ func (RuneTest) UnionsTwoSets() {
 	s2.Set(3)
 	s2.Set(4)
 
-	s := UnionRune([]runeSet{s1, s2})
+	s := UnionRune([]Rune{s1, s2})
 	expect.Expect(s.Exists(1)).To.Equal(true)
 	expect.Expect(s.Exists(2)).To.Equal(true)
 	expect.Expect(s.Exists(3)).To.Equal(true)
@@ -144,7 +144,7 @@ func Benchmark_RuneDenseIntersect(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		IntersectRune([]runeSet{s1, s2})
+		IntersectRune([]Rune{s1, s2})
 	}
 }
 

--- a/sized.go
+++ b/sized.go
@@ -5,9 +5,10 @@ import (
 	"sort"
 )
 
-var (
-	BUCKET_SIZE    = 32
-	BUCKET_GROW_BY = 8
+const (
+	bucketSize       int = 1
+	bucketGrowBy     int = 1
+	bucketMultiplier int = 1
 )
 
 type Set interface {
@@ -37,11 +38,11 @@ type Sized struct {
 }
 
 func NewSized(size int) *Sized {
-	if size < BUCKET_SIZE {
+	if size < bucketSize {
 		//random, no clue what to make it
-		size = BUCKET_SIZE * 2
+		size = bucketSize * bucketMultiplier
 	}
-	count := upTwo(size / BUCKET_SIZE)
+	count := upTwo(size / bucketSize)
 	s := &Sized{
 		mask:    count - 1,
 		buckets: make([][]int, count),
@@ -59,7 +60,7 @@ func (s *Sized) Set(value int) {
 	}
 	l := len(bucket)
 	if cap(bucket) == l {
-		n := make([]int, l, l+BUCKET_GROW_BY)
+		n := make([]int, l, l+bucketGrowBy)
 		copy(n, bucket)
 		bucket = n
 	}
@@ -120,7 +121,7 @@ func (s Sized) index(value int, bucket []int) (int, bool) {
 		return l, true
 	}
 
-	offset, i := 0, 0
+	var offset, i int
 	if value > v {
 		offset = l
 		bucket = bucket[offset:]

--- a/sized.go
+++ b/sized.go
@@ -3,23 +3,25 @@ package intset
 
 import "sort"
 
-type intSet interface {
+// Set defines int set methods
+type Set interface {
 	Len() int
 	Exists(value int) bool
 	Each(f func(value int))
 }
 
-type intSets []intSet
+// Sets is array of Set
+type Sets []Set
 
-func (s intSets) Len() int {
+func (s Sets) Len() int {
 	return len(s)
 }
 
-func (s intSets) Less(i, j int) bool {
+func (s Sets) Less(i, j int) bool {
 	return s[i].Len() < s[j].Len()
 }
 
-func (s intSets) Swap(i, j int) {
+func (s Sets) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
 
@@ -150,7 +152,7 @@ func (s Sized) exists(value int, bucket []int) bool {
 }
 
 // Intersect returns the intersection of an array of sets
-func Intersect(sets intSets) *Sized {
+func Intersect(sets Sets) *Sized {
 	sort.Sort(sets)
 	a, l := sets[0], sets.Len()
 	values := make([]int, 0, a.Len())
@@ -170,7 +172,7 @@ func Intersect(sets intSets) *Sized {
 }
 
 // Union returns the union of an array of sets
-func Union(sets intSets) *Sized {
+func Union(sets Sets) *Sized {
 	values := make(map[int]struct{}, sets[0].Len())
 	for i := 0; i < sets.Len(); i++ {
 		sets[i].Each(func(value int) {

--- a/sized.go
+++ b/sized.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	bucketSize       int = 1
+	bucketSize       int = 4
 	bucketGrowBy     int = 1
 	bucketMultiplier int = 1
 )
@@ -120,6 +120,8 @@ func (s Sized) index(value int, bucket []int) (int, bool) {
 	}
 	if value > v {
 		bucket = bucket[l:]
+	} else {
+		l = 0
 	}
 
 	var i int

--- a/sized.go
+++ b/sized.go
@@ -90,9 +90,7 @@ func (s *Sized) Remove(value int) bool {
 
 // Returns true if the value exists
 func (s *Sized) Exists(value int) bool {
-	bucket := s.buckets[value&s.mask]
-	_, exists := s.index(value, bucket)
-	return exists
+	return s.exists(value, s.buckets[value&s.mask])
 }
 
 // Total number of elements in the set
@@ -128,12 +126,34 @@ func (s Sized) index(value int, bucket []int) (int, bool) {
 	}
 
 	for i, v = range bucket {
-		if v < value {
-			continue
+		if v >= value {
+			return offset + i, v == value
 		}
-		return offset + i, v == value
 	}
 	return offset + i + 1, false
+}
+
+func (s Sized) exists(value int, bucket []int) bool {
+	l := len(bucket)
+	if l == 0 {
+		return false
+	}
+
+	l = l / 2
+	v := bucket[l]
+	if value == v {
+		return true
+	}
+	if value > v {
+		bucket = bucket[l:]
+	}
+
+	for _, v = range bucket {
+		if v >= value {
+			return v == value
+		}
+	}
+	return false
 }
 
 func Intersect(sets Sets) *Sized {

--- a/sized.go
+++ b/sized.go
@@ -118,19 +118,17 @@ func (s Sized) index(value int, bucket []int) (int, bool) {
 	if value == v {
 		return l, true
 	}
-
-	var offset, i int
 	if value > v {
-		offset = l
-		bucket = bucket[offset:]
+		bucket = bucket[l:]
 	}
 
+	var i int
 	for i, v = range bucket {
 		if v >= value {
-			return offset + i, v == value
+			return l + i, v == value
 		}
 	}
-	return offset + i + 1, false
+	return l + i + 1, false
 }
 
 func (s Sized) exists(value int, bucket []int) bool {

--- a/sized32.go
+++ b/sized32.go
@@ -109,19 +109,17 @@ func (s Sized32) index(value uint32, bucket []uint32) (int, bool) {
 	if value == v {
 		return l, true
 	}
-
-	var offset, i int
 	if value > v {
-		offset = l
-		bucket = bucket[offset:]
+		bucket = bucket[l:]
 	}
 
+	var i int
 	for i, v = range bucket {
 		if v >= value {
-			return offset + i, v == value
+			return l + i, v == value
 		}
 	}
-	return offset + i + 1, false
+	return l + i + 1, false
 }
 
 func (s Sized32) exists(value uint32, bucket []uint32) bool {

--- a/sized32.go
+++ b/sized32.go
@@ -32,11 +32,11 @@ type Sized32 struct {
 }
 
 func NewSized32(size uint32) *Sized32 {
-	if size < uint32(BUCKET_SIZE) {
+	if size < uint32(bucketSize) {
 		//random, no clue what to make it
-		size = uint32(BUCKET_SIZE * 2)
+		size = uint32(bucketSize) * uint32(bucketMultiplier)
 	}
-	count := upTwo(int(size) / BUCKET_SIZE)
+	count := upTwo(int(size) / bucketSize)
 	s := &Sized32{
 		mask:    uint32(count) - 1,
 		buckets: make([][]uint32, count),
@@ -53,7 +53,7 @@ func (s *Sized32) Set(value uint32) {
 	}
 	l := len(bucket)
 	if cap(bucket) == l {
-		n := make([]uint32, l, l+BUCKET_GROW_BY)
+		n := make([]uint32, l, l+bucketGrowBy)
 		copy(n, bucket)
 		bucket = n
 	}
@@ -112,7 +112,7 @@ func (s Sized32) index(value uint32, bucket []uint32) (int, bool) {
 		return l, true
 	}
 
-	offset, i := 0, 0
+	var offset, i int
 	if value > v {
 		offset = l
 		bucket = bucket[offset:]

--- a/sized32.go
+++ b/sized32.go
@@ -111,6 +111,8 @@ func (s Sized32) index(value uint32, bucket []uint32) (int, bool) {
 	}
 	if value > v {
 		bucket = bucket[l:]
+	} else {
+		l = 0
 	}
 
 	var i int

--- a/sized32.go
+++ b/sized32.go
@@ -82,9 +82,7 @@ func (s *Sized32) Remove(value uint32) bool {
 }
 
 func (s *Sized32) Exists(value uint32) bool {
-	bucket := s.buckets[value&s.mask]
-	_, exists := s.index(value, bucket)
-	return exists
+	return s.exists(value, s.buckets[value&s.mask])
 }
 
 func (s Sized32) Len() int {
@@ -119,12 +117,34 @@ func (s Sized32) index(value uint32, bucket []uint32) (int, bool) {
 	}
 
 	for i, v = range bucket {
-		if v < value {
-			continue
+		if v >= value {
+			return offset + i, v == value
 		}
-		return offset + i, v == value
 	}
 	return offset + i + 1, false
+}
+
+func (s Sized32) exists(value uint32, bucket []uint32) bool {
+	l := len(bucket)
+	if l == 0 {
+		return false
+	}
+
+	l = l / 2
+	v := bucket[l]
+	if value == v {
+		return true
+	}
+	if value > v {
+		bucket = bucket[l:]
+	}
+
+	for _, v = range bucket {
+		if v >= value {
+			return v == value
+		}
+	}
+	return false
 }
 
 func Intersect32(sets Sets32) *Sized32 {

--- a/sized32.go
+++ b/sized32.go
@@ -3,23 +3,25 @@ package intset
 
 import "sort"
 
-type uint32Set interface {
+// Set32 defines uint32 set methods
+type Set32 interface {
 	Len() int
 	Exists(value uint32) bool
 	Each(f func(value uint32))
 }
 
-type uint32Sets []uint32Set
+// Sets32 is array of Set32
+type Sets32 []Set32
 
-func (s uint32Sets) Len() int {
+func (s Sets32) Len() int {
 	return len(s)
 }
 
-func (s uint32Sets) Less(i, j int) bool {
+func (s Sets32) Less(i, j int) bool {
 	return s[i].Len() < s[j].Len()
 }
 
-func (s uint32Sets) Swap(i, j int) {
+func (s Sets32) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
 
@@ -150,7 +152,7 @@ func (s Sized32) exists(value uint32, bucket []uint32) bool {
 }
 
 // Intersect32 returns the intersection of an array of sets
-func Intersect32(sets uint32Sets) *Sized32 {
+func Intersect32(sets Sets32) *Sized32 {
 	sort.Sort(sets)
 	a, l := sets[0], sets.Len()
 	values := make([]uint32, 0, a.Len())
@@ -170,7 +172,7 @@ func Intersect32(sets uint32Sets) *Sized32 {
 }
 
 // Union32 returns the union of an array of sets
-func Union32(sets uint32Sets) *Sized32 {
+func Union32(sets Sets32) *Sized32 {
 	values := make(map[uint32]struct{}, sets[0].Len())
 	for i := 0; i < sets.Len(); i++ {
 		sets[i].Each(func(value uint32) {

--- a/sized32_test.go
+++ b/sized32_test.go
@@ -35,7 +35,7 @@ func (Sized32Test) Exists() {
 }
 
 func (Sized32Test) SizeLessThanBucket() {
-	s := NewSized32(uint32(BUCKET_SIZE) - 1)
+	s := NewSized32(uint32(bucketSize) - 1)
 	s.Set(32)
 	expect.Expect(s.Exists(32)).To.Equal(true)
 	expect.Expect(s.Exists(33)).To.Equal(false)
@@ -109,12 +109,9 @@ func Benchmark_Sized32DenseExists(b *testing.B) {
 	for i := uint32(0); i < 1000000; i++ {
 		s.Set(i)
 	}
-	misses := 0
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if s.Exists(uint32(i%1000000)) == false {
-			misses++
-		}
+		s.Exists(uint32(i % 1000000))
 	}
 }
 
@@ -125,11 +122,8 @@ func Benchmark_Sized32SparseExists(b *testing.B) {
 			s.Set(i)
 		}
 	}
-	misses := 0
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if s.Exists(uint32(i%1000000)) == false {
-			misses++
-		}
+		s.Exists(uint32(i % 1000000))
 	}
 }

--- a/sized32_test.go
+++ b/sized32_test.go
@@ -1,6 +1,7 @@
 package intset
 
 import (
+	"math/rand"
 	"testing"
 
 	expect "github.com/karlseguin/expect"
@@ -69,7 +70,7 @@ func (Sized32Test) IntersectsTwoSets() {
 	s2.Set(3)
 	s2.Set(4)
 
-	s := Intersect32([]Set32{s1, s2})
+	s := Intersect32([]uint32Set{s1, s2})
 	expect.Expect(s.Exists(1)).To.Equal(false)
 	expect.Expect(s.Exists(2)).To.Equal(true)
 	expect.Expect(s.Exists(3)).To.Equal(true)
@@ -88,7 +89,7 @@ func (Sized32Test) UnionsTwoSets() {
 	s2.Set(3)
 	s2.Set(4)
 
-	s := Union32([]Set32{s1, s2})
+	s := Union32([]uint32Set{s1, s2})
 	expect.Expect(s.Exists(1)).To.Equal(true)
 	expect.Expect(s.Exists(2)).To.Equal(true)
 	expect.Expect(s.Exists(3)).To.Equal(true)
@@ -125,5 +126,50 @@ func Benchmark_Sized32SparseExists(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		s.Exists(uint32(i % 1000000))
+	}
+}
+
+func Benchmark_Sized32DenseIntersect(b *testing.B) {
+	s1 := NewSized32(100000)
+	for i := uint32(0); i < 100000; i++ {
+		if rand.Intn(10) != 0 {
+			s1.Set(i)
+		}
+	}
+	s2 := NewSized32(1000)
+	for i := uint32(0); i < 1000; i++ {
+		if rand.Intn(10) != 0 {
+			s2.Set(i)
+		}
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Intersect32([]uint32Set{s1, s2})
+	}
+}
+
+// Benchmarks for map[uint32]struct{}
+
+func Benchmark_Sized32MapDenseExists(b *testing.B) {
+	s := make(map[uint32]struct{})
+	for i := uint32(0); i < 1000000; i++ {
+		s[i] = struct{}{}
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = s[uint32(i)]
+	}
+}
+
+func Benchmark_Sized32MapSparseExists(b *testing.B) {
+	s := make(map[uint32]struct{})
+	for i := uint32(0); i < 1000000; i++ {
+		if i%10 == 0 {
+			s[i] = struct{}{}
+		}
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = s[uint32(i%1000000)]
 	}
 }

--- a/sized32_test.go
+++ b/sized32_test.go
@@ -70,7 +70,7 @@ func (Sized32Test) IntersectsTwoSets() {
 	s2.Set(3)
 	s2.Set(4)
 
-	s := Intersect32([]uint32Set{s1, s2})
+	s := Intersect32([]Set32{s1, s2})
 	expect.Expect(s.Exists(1)).To.Equal(false)
 	expect.Expect(s.Exists(2)).To.Equal(true)
 	expect.Expect(s.Exists(3)).To.Equal(true)
@@ -89,7 +89,7 @@ func (Sized32Test) UnionsTwoSets() {
 	s2.Set(3)
 	s2.Set(4)
 
-	s := Union32([]uint32Set{s1, s2})
+	s := Union32([]Set32{s1, s2})
 	expect.Expect(s.Exists(1)).To.Equal(true)
 	expect.Expect(s.Exists(2)).To.Equal(true)
 	expect.Expect(s.Exists(3)).To.Equal(true)
@@ -144,7 +144,7 @@ func Benchmark_Sized32DenseIntersect(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		Intersect32([]uint32Set{s1, s2})
+		Intersect32([]Set32{s1, s2})
 	}
 }
 

--- a/sized_test.go
+++ b/sized_test.go
@@ -70,7 +70,7 @@ func (SizedTest) IntersectsTwoSets() {
 	s2.Set(3)
 	s2.Set(4)
 
-	s := Intersect([]intSet{s1, s2})
+	s := Intersect([]Set{s1, s2})
 	expect.Expect(s.Exists(1)).To.Equal(false)
 	expect.Expect(s.Exists(2)).To.Equal(true)
 	expect.Expect(s.Exists(3)).To.Equal(true)
@@ -90,7 +90,7 @@ func (SizedTest) UnionsTwoSets() {
 		s2.Set(3)
 		s2.Set(4)
 
-		s := Union([]intSet{s1, s2})
+		s := Union([]Set{s1, s2})
 		expect.Expect(s.Exists(1)).To.Equal(true)
 		expect.Expect(s.Exists(2)).To.Equal(true)
 		expect.Expect(s.Exists(3)).To.Equal(true)
@@ -146,7 +146,7 @@ func Benchmark_SizedDenseIntersect(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		Intersect([]intSet{s1, s2})
+		Intersect([]Set{s1, s2})
 	}
 }
 

--- a/sized_test.go
+++ b/sized_test.go
@@ -70,7 +70,7 @@ func (SizedTest) IntersectsTwoSets() {
 	s2.Set(3)
 	s2.Set(4)
 
-	s := Intersect([]Set{s1, s2})
+	s := Intersect([]intSet{s1, s2})
 	expect.Expect(s.Exists(1)).To.Equal(false)
 	expect.Expect(s.Exists(2)).To.Equal(true)
 	expect.Expect(s.Exists(3)).To.Equal(true)
@@ -90,7 +90,7 @@ func (SizedTest) UnionsTwoSets() {
 		s2.Set(3)
 		s2.Set(4)
 
-		s := Union([]Set{s1, s2})
+		s := Union([]intSet{s1, s2})
 		expect.Expect(s.Exists(1)).To.Equal(true)
 		expect.Expect(s.Exists(2)).To.Equal(true)
 		expect.Expect(s.Exists(3)).To.Equal(true)
@@ -146,6 +146,32 @@ func Benchmark_SizedDenseIntersect(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		Intersect([]Set{s1, s2})
+		Intersect([]intSet{s1, s2})
+	}
+}
+
+// Benchmarks for map[int]struct{}
+
+func Benchmark_SizedMapDenseExists(b *testing.B) {
+	s := make(map[int]struct{})
+	for i := 0; i < 1000000; i++ {
+		s[i] = struct{}{}
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = s[i]
+	}
+}
+
+func Benchmark_SizedMapSparseExists(b *testing.B) {
+	s := make(map[int]struct{})
+	for i := 0; i < 1000000; i++ {
+		if i%10 == 0 {
+			s[i] = struct{}{}
+		}
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = s[i%1000000]
 	}
 }

--- a/sized_test.go
+++ b/sized_test.go
@@ -1,64 +1,65 @@
 package intset
 
 import (
-	. "github.com/karlseguin/expect"
 	"math/rand"
 	"testing"
+
+	expect "github.com/karlseguin/expect"
 )
 
 type SizedTest struct{}
 
 func Test_Sized(t *testing.T) {
-	Expectify(new(SizedTest), t)
+	expect.Expectify(new(SizedTest), t)
 }
 
-func (_ SizedTest) SetsAValue() {
+func (SizedTest) SetsAValue() {
 	s := NewSized(20)
 	for i := 0; i < 30; i++ {
 		s.Set(i)
-		Expect(s.Exists(i)).To.Equal(true)
+		expect.Expect(s.Exists(i)).To.Equal(true)
 	}
 	for i := 0; i < 30; i++ {
-		Expect(s.Exists(i)).To.Equal(true)
+		expect.Expect(s.Exists(i)).To.Equal(true)
 	}
 }
 
-func (_ SizedTest) Exists() {
+func (SizedTest) Exists() {
 	s := NewSized(20)
 	for i := 0; i < 100; i++ {
-		Expect(s.Exists(i)).To.Equal(false)
+		expect.Expect(s.Exists(i)).To.Equal(false)
 		s.Set(i)
 	}
 	for i := 0; i < 100; i++ {
-		Expect(s.Exists(i)).To.Equal(true)
+		expect.Expect(s.Exists(i)).To.Equal(true)
 	}
 }
 
-func (_ SizedTest) SizeLessThanBucket() {
+func (SizedTest) SizeLessThanBucket() {
 	s := NewSized(BUCKET_SIZE - 1)
 	s.Set(32)
-	Expect(s.Exists(32)).To.Equal(true)
-	Expect(s.Exists(33)).To.Equal(false)
+	expect.Expect(s.Exists(32)).To.Equal(true)
+	expect.Expect(s.Exists(33)).To.Equal(false)
 }
 
-func (_ SizedTest) RemoveNonMembers() {
+func (SizedTest) RemoveNonMembers() {
 	s := NewSized(100)
-	Expect(s.Remove(329)).To.Equal(false)
+	expect.Expect(s.Remove(329)).To.Equal(false)
 }
 
-func (_ SizedTest) RemovesMembers() {
+func (SizedTest) RemovesMembers() {
 	s := NewSized(100)
 	for i := 0; i < 10; i++ {
 		s.Set(i)
 	}
-	Expect(s.Remove(20)).To.Equal(false)
-	Expect(s.Remove(2)).To.Equal(true)
-	Expect(s.Remove(2)).To.Equal(false)
-	Expect(s.Exists(2)).To.Equal(false)
-	Expect(s.Len()).To.Equal(9)
+	expect.Expect(s.Remove(20)).To.Equal(false)
+	expect.Expect(s.Remove(2)).To.Equal(true)
+	expect.Expect(s.Remove(2)).To.Equal(false)
+	expect.Expect(s.Exists(2)).To.Equal(false)
+	expect.Expect(s.Len()).To.Equal(9)
 }
 
-func (_ SizedTest) IntersectsTwoSets() {
+func (SizedTest) IntersectsTwoSets() {
 	s1 := NewSized(10)
 	s2 := NewSized(10)
 	s1.Set(1)
@@ -70,14 +71,14 @@ func (_ SizedTest) IntersectsTwoSets() {
 	s2.Set(4)
 
 	s := Intersect([]Set{s1, s2})
-	Expect(s.Exists(1)).To.Equal(false)
-	Expect(s.Exists(2)).To.Equal(true)
-	Expect(s.Exists(3)).To.Equal(true)
-	Expect(s.Exists(4)).To.Equal(false)
-	Expect(s.Exists(5)).To.Equal(false)
+	expect.Expect(s.Exists(1)).To.Equal(false)
+	expect.Expect(s.Exists(2)).To.Equal(true)
+	expect.Expect(s.Exists(3)).To.Equal(true)
+	expect.Expect(s.Exists(4)).To.Equal(false)
+	expect.Expect(s.Exists(5)).To.Equal(false)
 }
 
-func (_ SizedTest) UnionsTwoSets() {
+func (SizedTest) UnionsTwoSets() {
 	for i := 0; i < 1000; i++ {
 		s1 := NewSized(10)
 		s2 := NewSized(10)
@@ -90,11 +91,11 @@ func (_ SizedTest) UnionsTwoSets() {
 		s2.Set(4)
 
 		s := Union([]Set{s1, s2})
-		Expect(s.Exists(1)).To.Equal(true)
-		Expect(s.Exists(2)).To.Equal(true)
-		Expect(s.Exists(3)).To.Equal(true)
-		Expect(s.Exists(4)).To.Equal(true)
-		Expect(s.Exists(5)).To.Equal(false)
+		expect.Expect(s.Exists(1)).To.Equal(true)
+		expect.Expect(s.Exists(2)).To.Equal(true)
+		expect.Expect(s.Exists(3)).To.Equal(true)
+		expect.Expect(s.Exists(4)).To.Equal(true)
+		expect.Expect(s.Exists(5)).To.Equal(false)
 	}
 }
 

--- a/sized_test.go
+++ b/sized_test.go
@@ -36,7 +36,7 @@ func (SizedTest) Exists() {
 }
 
 func (SizedTest) SizeLessThanBucket() {
-	s := NewSized(BUCKET_SIZE - 1)
+	s := NewSized(bucketSize - 1)
 	s.Set(32)
 	expect.Expect(s.Exists(32)).To.Equal(true)
 	expect.Expect(s.Exists(33)).To.Equal(false)
@@ -112,12 +112,9 @@ func Benchmark_SizedDenseExists(b *testing.B) {
 	for i := 0; i < 1000000; i++ {
 		s.Set(i)
 	}
-	misses := 0
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if s.Exists(i%1000000) == false {
-			misses++
-		}
+		s.Exists(i % 1000000)
 	}
 }
 
@@ -128,12 +125,9 @@ func Benchmark_SizedSparseExists(b *testing.B) {
 			s.Set(i)
 		}
 	}
-	misses := 0
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if s.Exists(i%1000000) == false {
-			misses++
-		}
+		s.Exists(i % 1000000)
 	}
 }
 


### PR DESCRIPTION
First, temporarily change the first line in `go.mod` to `module github.com/elliotwutingfeng/intset`

## Changes

- Support rune sets; possible applications include checking strings for prohibited characters etc.
- Improve lookup speed by replacing `index()` method with new `exists()` method that omits unused variables.
- Improve lookup speed by changing bucketSize, bucketGrowBy, bucketMultiplier to 4, 1, 1; tradeoff is **~22%** increase in memory usage compared to existing intset implementation.
- Add docstrings to exported functions.
- README: Fix typos, add badges, mention new rune set feature.
- Add benchmarks for sets implemented with `map[T]struct{}`, for comparison with intset.

## Benchmarks

Memory usage benchmarking done with **pprof**

Speed benchmarking done using vscode's golang codelens extension

Benchmarks performed on AMD Ryzen 7 5800X, Manjaro Linux.

```bash
go test -cpuprofile cpu.prof -memprofile mem.prof -bench . -cpu 1
go tool pprof mem.prof
web
```

| bucketSize                                     | Benchmark_RuneMapDenseExists | Benchmark_RuneMapSparseExists | Total Memory Usage |
|------------------------------------------------|------------------------------|-------------------------------|--------------------|
| 1                                              | 1.215ns/op                   | 1.142ns/op                    | 15916.34MB         |
| 2                                              | 1.348ns/op                   | 1.165ns/op                    | 9075.40MB          |
| 4                                              | 1.638ns/op                   | 1.391ns/op                    | 6961.48MB          |
| 8                                              | 2.156ns/op                   | 1.451ns/op                    | 7268.57MB          |
| 32 (bucketGrowBy = 4 and bucketMultiplier = 2) | 4.002ns/op                   | 1.654ns/op                    | 5713.25MB          |

- The bottom row is the original intset implementation.
- Benchmarks indicate that intset lookups are approximately 7 times faster than traditional sets implemented with `map[T]struct{}`.
- Smaller bucketSize is faster but memory usage is very high.
- Strangely, bucketSize 8 has slightly higher memory usage than bucketSize 4.
- bucketSize 4 was chosen as it gives the best speed-memory tradeoff.