### PR TITLE
Fix benchmark Makefile and speed up exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,17 @@
-t:
-	go test .
+t:  # test
+	go test -v -race -covermode atomic -coverprofile coverage.out && go tool cover -html coverage.out -o coverage.html
 
-f:
+f:  # format
 	go fmt .
 
-b:
-	go test -bench=. -vv
+b:  # benchmark
+	go test -bench . -benchmem -cpu 1
+
+r:  # report benchmark
+	go test -cpuprofile cpu.prof -memprofile mem.prof -bench . -cpu 1
+
+c:  # cpu profile
+	go tool pprof cpu.prof
+
+m:  # memory profile
+	go tool pprof mem.prof

--- a/rune.go
+++ b/rune.go
@@ -136,21 +136,11 @@ func (s Rune) index(value rune, bucket []rune) (int, bool) {
 }
 
 func (s Rune) exists(value rune, bucket []rune) bool {
-	l := len(bucket)
-	if l == 0 {
+	if len(bucket) == 0 {
 		return false
 	}
 
-	l = l / 2
-	v := bucket[l]
-	if value == v {
-		return true
-	}
-	if value > v {
-		bucket = bucket[l:]
-	}
-
-	for _, v = range bucket {
+	for _, v := range bucket {
 		if v >= value {
 			return v == value
 		}

--- a/sized.go
+++ b/sized.go
@@ -136,21 +136,11 @@ func (s Sized) index(value int, bucket []int) (int, bool) {
 }
 
 func (s Sized) exists(value int, bucket []int) bool {
-	l := len(bucket)
-	if l == 0 {
+	if len(bucket) == 0 {
 		return false
 	}
 
-	l = l / 2
-	v := bucket[l]
-	if value == v {
-		return true
-	}
-	if value > v {
-		bucket = bucket[l:]
-	}
-
-	for _, v = range bucket {
+	for _, v := range bucket {
 		if v >= value {
 			return v == value
 		}

--- a/sized32.go
+++ b/sized32.go
@@ -136,21 +136,11 @@ func (s Sized32) index(value uint32, bucket []uint32) (int, bool) {
 }
 
 func (s Sized32) exists(value uint32, bucket []uint32) bool {
-	l := len(bucket)
-	if l == 0 {
+	if len(bucket) == 0 {
 		return false
 	}
 
-	l = l / 2
-	v := bucket[l]
-	if value == v {
-		return true
-	}
-	if value > v {
-		bucket = bucket[l:]
-	}
-
-	for _, v = range bucket {
+	for _, v := range bucket {
 		if v >= value {
 			return v == value
 		}


### PR DESCRIPTION
- Fixed benchmark Makefile; `go test -bench=. -vv` was invalid
- Removed micro-ops from exists() which were slowing it down.